### PR TITLE
force ajv strict options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 ### Changed
 
+## [v1.1.4] 18-07-2021
+### Changed
+ - force AJV options strict:false and validateFormats:false even if user supplies empty ajvOptions 
+
 ## [v1.1.3] 28-05-2021
 ### Changed
 - Support schema 3.1 2021-05-20

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ if (res.valid) {
 ### `new Validator(ajvOptions)`
 
 The constructor returns an instance of `Validator`. 
-By passing an ajv options object it is possible to influence the behavior of the [AJV schema validator](https://ajv.js.org/). 
+By passing an ajv options object it is possible to influence the behavior of the [AJV schema validator](https://ajv.js.org/). AJV fails to process the openApi schemas if you set `strict:true` or `validateFormats: true` therefore these are overridden and set to `false` if present. This is not a bug but a result of the complexity of the openApi JSON schemas.
 
 <a name="validate"></a>
 ### `<instance>.validate(specification)`

--- a/index.js
+++ b/index.js
@@ -46,7 +46,13 @@ async function getSpecFromData(data) {
 }
 
 class Validator {
-  constructor(ajvOptions = { strict: false, validateFormats: false }) {
+  constructor(ajvOptions = {}) {
+    // AJV is a bit too strict in its strict validation of openAPI schemas
+    // so switch strict mode and validateFormats off
+    if (ajvOptions.strict !== "log") {
+      ajvOptions.strict = false;
+    }
+    ajvOptions.validateFormats = false;
     this.ajvOptions = ajvOptions;
     return this;
   }

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -123,6 +123,27 @@ test(`original petstore spec works`, async (t) => {
   );
 });
 
+test(`original petstore spec works with AJV strict:"log" option`, async (t) => {
+  t.plan(3);
+  const validator = new Validator({ strict: "log" });
+  const petStoreSpec = require(`./validation/petstore-swagger.v2.json`);
+  const res = await validator.validate(petStoreSpec);
+  console.log(res.errors);
+  t.equal(res.valid, true, "original petstore spec is valid");
+  const ver = validator.version;
+  t.equal(
+    ver,
+    "2.0",
+    "original petstore spec version matches expected version"
+  );
+  const resolvedSpec = validator.resolveRefs();
+  t.equal(
+    resolvedSpec.paths["/pet"].post.parameters[0].schema.required[0],
+    "name",
+    "$refs are correctly resolved"
+  );
+});
+
 test(`Invalid filename returns an error`, async (t) => {
   t.plan(2);
   const validator = new Validator();


### PR DESCRIPTION
set ajv options strict and validateFormats to false if user supplied an empty object or set them explicitly to true.