### PR TITLE
use ajv-draft-04

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const Ajv = require("ajv");
+const Ajv04 = require("ajv-draft-04");
 const Ajv2020 = require("ajv/dist/2020.js");
 const JSYaml = require("js-yaml");
 const util = require("util");
@@ -9,7 +9,7 @@ const { resolve } = require("./resolve.js");
 
 const openApiVersions = new Set(["2.0", "3.0", "3.1"]);
 const ajvVersions = {
-  "http://json-schema.org/draft-07/schema": Ajv,
+  "http://json-schema.org/draft-04/schema#": Ajv04,
   "https://json-schema.org/draft/2020-12/schema": Ajv2020,
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.6.0",
+        "ajv-draft-04": "^1.0.0",
         "js-yaml": "^4.1.0"
       },
       "devDependencies": {
@@ -326,6 +327,19 @@
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -4938,6 +4952,12 @@
         "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       }
+    },
+    "ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "requires": {}
     },
     "ansi-regex": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "commonjs",
   "dependencies": {
     "ajv": "^8.6.0",
+    "ajv-draft-04": "^1.0.0",
     "js-yaml": "^4.1.0"
   },
   "scripts": {

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,7 +1,6 @@
 # The schemas
 This folder contain the JSON schemas for the openApi specifications as used by this package.
-The original schemas from the [openApi specification repository](https://github.com/OAI/OpenAPI-Specification) have been slightly modified to work with the current AJV version that this package uses.
+The original OAS 3.1 schemas from the [openApi specification repository](https://github.com/OAI/OpenAPI-Specification) have been slightly modified to work with the current AJV version that this package uses.
 This means:
-- migrating schemas from JSONschema-draft-04 to JSONschema-draft-07 as AJV does not support draft-04 anymore.
-- replacing $dynamicRefs by normal $refs as the current version of AJV has an issue with resolving $dynamicRefs outside the root object.
+- replacing $dynamicRefs by normal $refs as the current version of AJV has an issue with resolving $dynamicRefs outside the root object in draft-2020-12 specs.
 

--- a/schemas/v2.0/schema.json
+++ b/schemas/v2.0/schema.json
@@ -1,7 +1,7 @@
 {
   "title": "A JSON Schema for Swagger 2.0 API.",
-  "$id": "http://swagger.io/v2/schema.json#",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "id": "http://swagger.io/v2/schema.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": [
     "swagger",
@@ -17,7 +17,9 @@
   "properties": {
     "swagger": {
       "type": "string",
-      "const": "2.0",
+      "enum": [
+        "2.0"
+      ],
       "description": "The Swagger version of this document."
     },
     "info": {
@@ -487,7 +489,9 @@
       }
     },
     "vendorExtension": {
-      "description": "Any property starting with x- is valid."
+      "description": "Any property starting with x- is valid.",
+      "additionalProperties": true,
+      "additionalItems": true
     },
     "bodyParameter": {
       "type": "object",
@@ -513,7 +517,9 @@
         "in": {
           "type": "string",
           "description": "Determines the location of the parameter.",
-          "const": "body"
+          "enum": [
+            "body"
+          ]
         },
         "required": {
           "type": "boolean",
@@ -542,7 +548,9 @@
         "in": {
           "type": "string",
           "description": "Determines the location of the parameter.",
-          "const": "header"
+          "enum": [
+            "header"
+          ]
         },
         "description": {
           "type": "string",
@@ -628,7 +636,9 @@
         "in": {
           "type": "string",
           "description": "Determines the location of the parameter.",
-          "const": "query"
+          "enum": [
+            "query"
+          ]
         },
         "description": {
           "type": "string",
@@ -719,7 +729,9 @@
         "in": {
           "type": "string",
           "description": "Determines the location of the parameter.",
-          "const": "formData"
+          "enum": [
+            "formData"
+          ]
         },
         "description": {
           "type": "string",
@@ -808,13 +820,17 @@
       "properties": {
         "required": {
           "type": "boolean",
-          "const": true,
+          "enum": [
+            true
+          ],
           "description": "Determines whether or not this parameter is required or optional."
         },
         "in": {
           "type": "string",
           "description": "Determines the location of the parameter.",
-          "const": "path"
+          "enum": [
+            "path"
+          ]
         },
         "description": {
           "type": "string",
@@ -932,58 +948,58 @@
           "type": "string"
         },
         "title": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
         },
         "description": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
         },
         "default": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/default"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
         },
         "multipleOf": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/multipleOf"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
         },
         "maximum": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/maximum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
         },
         "exclusiveMaximum": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
         },
         "minimum": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/minimum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
         },
         "exclusiveMinimum": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMinimum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
         },
         "maxLength": {
-          "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minLength": {
-          "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "pattern": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/pattern"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
         },
         "maxItems": {
-          "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minItems": {
-          "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "uniqueItems": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/uniqueItems"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
         },
         "maxProperties": {
-          "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minProperties": {
-          "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "required": {
-          "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
         },
         "enum": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/enum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
         },
         "additionalProperties": {
           "anyOf": [
@@ -997,7 +1013,7 @@
           "default": {}
         },
         "type": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/type"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
         },
         "items": {
           "anyOf": [
@@ -1041,7 +1057,7 @@
         "externalDocs": {
           "$ref": "#/definitions/externalDocs"
         },
-        "example": true
+        "example": {}
       },
       "additionalProperties": false
     },
@@ -1061,20 +1077,22 @@
           "type": "string"
         },
         "title": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
         },
         "description": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
         },
         "default": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/default"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
         },
         "required": {
-          "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
         },
         "type": {
           "type": "string",
-          "const": "file"
+          "enum": [
+            "file"
+          ]
         },
         "readOnly": {
           "type": "boolean",
@@ -1083,7 +1101,7 @@
         "externalDocs": {
           "$ref": "#/definitions/externalDocs"
         },
-        "example": true
+        "example": {}
       },
       "additionalProperties": false
     },
@@ -1258,7 +1276,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "const": "basic"
+          "enum": [
+            "basic"
+          ]
         },
         "description": {
           "type": "string"
@@ -1281,7 +1301,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "const": "apiKey"
+          "enum": [
+            "apiKey"
+          ]
         },
         "name": {
           "type": "string"
@@ -1314,11 +1336,15 @@
       "properties": {
         "type": {
           "type": "string",
-          "const": "oauth2"
+          "enum": [
+            "oauth2"
+          ]
         },
         "flow": {
           "type": "string",
-          "const": "implicit"
+          "enum": [
+            "implicit"
+          ]
         },
         "scopes": {
           "$ref": "#/definitions/oauth2Scopes"
@@ -1348,11 +1374,15 @@
       "properties": {
         "type": {
           "type": "string",
-          "const": "oauth2"
+          "enum": [
+            "oauth2"
+          ]
         },
         "flow": {
           "type": "string",
-          "const": "password"
+          "enum": [
+            "password"
+          ]
         },
         "scopes": {
           "$ref": "#/definitions/oauth2Scopes"
@@ -1382,11 +1412,15 @@
       "properties": {
         "type": {
           "type": "string",
-          "const": "oauth2"
+          "enum": [
+            "oauth2"
+          ]
         },
         "flow": {
           "type": "string",
-          "const": "application"
+          "enum": [
+            "application"
+          ]
         },
         "scopes": {
           "$ref": "#/definitions/oauth2Scopes"
@@ -1417,11 +1451,15 @@
       "properties": {
         "type": {
           "type": "string",
-          "const": "oauth2"
+          "enum": [
+            "oauth2"
+          ]
         },
         "flow": {
           "type": "string",
-          "const": "accessCode"
+          "enum": [
+            "accessCode"
+          ]
         },
         "scopes": {
           "$ref": "#/definitions/oauth2Scopes"
@@ -1509,49 +1547,49 @@
       "default": "csv"
     },
     "title": {
-      "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
     },
     "description": {
-      "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
     },
     "default": {
-      "$ref": "http://json-schema.org/draft-07/schema#/properties/default"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
     },
     "multipleOf": {
-      "$ref": "http://json-schema.org/draft-07/schema#/properties/multipleOf"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
     },
     "maximum": {
-      "$ref": "http://json-schema.org/draft-07/schema#/properties/maximum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
     },
     "exclusiveMaximum": {
-      "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
     },
     "minimum": {
-      "$ref": "http://json-schema.org/draft-07/schema#/properties/minimum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
     },
     "exclusiveMinimum": {
-      "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMinimum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
     },
     "maxLength": {
-      "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
     },
     "minLength": {
-      "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
     },
     "pattern": {
-      "$ref": "http://json-schema.org/draft-07/schema#/properties/pattern"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
     },
     "maxItems": {
-      "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
     },
     "minItems": {
-      "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
     },
     "uniqueItems": {
-      "$ref": "http://json-schema.org/draft-07/schema#/properties/uniqueItems"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
     },
     "enum": {
-      "$ref": "http://json-schema.org/draft-07/schema#/properties/enum"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
     },
     "jsonReference": {
       "type": "object",

--- a/schemas/v3.0/schema.json
+++ b/schemas/v3.0/schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://spec.openapis.org/oas/3.0/schema/2019-04-02",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "id": "https://spec.openapis.org/oas/3.0/schema/2019-04-02",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Validation schema for OpenAPI Specification 3.0.X.",
   "type": "object",
   "required": [
@@ -46,7 +46,8 @@
     }
   },
   "patternProperties": {
-    "^x-": true
+    "^x-": {
+    }
   },
   "additionalProperties": false,
   "definitions": {
@@ -90,7 +91,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -110,7 +112,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -129,7 +132,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -153,7 +157,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -177,7 +182,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -321,7 +327,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -333,7 +340,8 @@
         },
         "multipleOf": {
           "type": "number",
-          "exclusiveMinimum": 0
+          "minimum": 0,
+          "exclusiveMinimum": true
         },
         "maximum": {
           "type": "number"
@@ -394,7 +402,8 @@
         },
         "enum": {
           "type": "array",
-          "items": true,
+          "items": {
+          },
           "minItems": 1,
           "uniqueItems": false
         },
@@ -501,7 +510,8 @@
         "format": {
           "type": "string"
         },
-        "default": true,
+        "default": {
+        },
         "nullable": {
           "type": "boolean",
           "default": false
@@ -517,7 +527,8 @@
           "type": "boolean",
           "default": false
         },
-        "example": true,
+        "example": {
+        },
         "externalDocs": {
           "$ref": "#/definitions/ExternalDocumentation"
         },
@@ -530,7 +541,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -574,7 +586,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -621,7 +634,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -638,7 +652,8 @@
             }
           ]
         },
-        "example": true,
+        "example": {
+        },
         "examples": {
           "type": "object",
           "additionalProperties": {
@@ -660,7 +675,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false,
       "allOf": [
@@ -678,14 +694,16 @@
         "description": {
           "type": "string"
         },
-        "value": true,
+        "value": {
+        },
         "externalValue": {
           "type": "string",
           "format": "uri-reference"
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -709,7 +727,9 @@
         },
         "style": {
           "type": "string",
-          "const": "simple",
+          "enum": [
+            "simple"
+          ],
           "default": "simple"
         },
         "explode": {
@@ -737,7 +757,8 @@
           "minProperties": 1,
           "maxProperties": 1
         },
-        "example": true,
+        "example": {
+        },
         "examples": {
           "type": "object",
           "additionalProperties": {
@@ -753,7 +774,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false,
       "allOf": [
@@ -771,7 +793,8 @@
         "^\\/": {
           "$ref": "#/definitions/PathItem"
         },
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -812,7 +835,8 @@
         "^(get|put|post|delete|options|head|patch|trace)$": {
           "$ref": "#/definitions/Operation"
         },
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -898,7 +922,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -927,7 +952,8 @@
             }
           ]
         },
-        "^x-": true
+        "^x-": {
+        }
       },
       "minProperties": 1,
       "additionalProperties": false
@@ -958,7 +984,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -977,7 +1004,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1101,7 +1129,8 @@
           "minProperties": 1,
           "maxProperties": 1
         },
-        "example": true,
+        "example": {
+        },
         "examples": {
           "type": "object",
           "additionalProperties": {
@@ -1117,7 +1146,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false,
       "required": [
@@ -1146,7 +1176,9 @@
           ],
           "properties": {
             "in": {
-              "const": "path"
+              "enum": [
+                "path"
+              ]
             },
             "style": {
               "enum": [
@@ -1157,7 +1189,9 @@
               "default": "simple"
             },
             "required": {
-              "const": true
+              "enum": [
+                true
+              ]
             }
           }
         },
@@ -1165,7 +1199,9 @@
           "description": "Parameter in query",
           "properties": {
             "in": {
-              "const": "query"
+              "enum": [
+                "query"
+              ]
             },
             "style": {
               "enum": [
@@ -1182,10 +1218,14 @@
           "description": "Parameter in header",
           "properties": {
             "in": {
-              "const": "header"
+              "enum": [
+                "header"
+              ]
             },
             "style": {
-              "const": "simple",
+              "enum": [
+                "simple"
+              ],
               "default": "simple"
             }
           }
@@ -1194,10 +1234,14 @@
           "description": "Parameter in cookie",
           "properties": {
             "in": {
-              "const": "cookie"
+              "enum": [
+                "cookie"
+              ]
             },
             "style": {
-              "const": "form",
+              "enum": [
+                "form"
+              ],
               "default": "form"
             }
           }
@@ -1225,7 +1269,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1255,7 +1300,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "const": "apiKey"
+          "enum": [
+            "apiKey"
+          ]
         },
         "name": {
           "type": "string"
@@ -1273,7 +1320,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1295,11 +1343,14 @@
         },
         "type": {
           "type": "string",
-          "const": "http"
+          "enum": [
+            "http"
+          ]
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false,
       "oneOf": [
@@ -1307,7 +1358,9 @@
           "description": "Bearer",
           "properties": {
             "scheme": {
-              "const": "bearer"
+              "enum": [
+                "bearer"
+              ]
             }
           }
         },
@@ -1321,7 +1374,9 @@
           "properties": {
             "scheme": {
               "not": {
-                "const": "bearer"
+                "enum": [
+                  "bearer"
+                ]
               }
             }
           }
@@ -1337,7 +1392,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "const": "oauth2"
+          "enum": [
+            "oauth2"
+          ]
         },
         "flows": {
           "$ref": "#/definitions/OAuthFlows"
@@ -1347,7 +1404,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1360,7 +1418,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "const": "openIdConnect"
+          "enum": [
+            "openIdConnect"
+          ]
         },
         "openIdConnectUrl": {
           "type": "string",
@@ -1371,7 +1431,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1392,7 +1453,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1419,7 +1481,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1445,7 +1508,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1471,7 +1535,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1502,7 +1567,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false
     },
@@ -1518,9 +1584,11 @@
         },
         "parameters": {
           "type": "object",
-          "additionalProperties": true
+          "additionalProperties": {
+          }
         },
-        "requestBody": true,
+        "requestBody": {
+        },
         "description": {
           "type": "string"
         },
@@ -1529,7 +1597,8 @@
         }
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       },
       "additionalProperties": false,
       "not": {
@@ -1546,7 +1615,8 @@
         "$ref": "#/definitions/PathItem"
       },
       "patternProperties": {
-        "^x-": true
+        "^x-": {
+        }
       }
     },
     "Encoding": {

--- a/test/realworld/failed.json
+++ b/test/realworld/failed.json
@@ -1,79 +1,4 @@
 {
-  "appcenter.ms": {
-    "name": "appcenter.ms",
-    "apiVersion": "v0.1",
-    "openApiVersion": "2.0",
-    "yamlUrl": "https://api.apis.guru/v2/specs/appcenter.ms/v0.1/swagger.yaml",
-    "jsonUrl": "https://api.apis.guru/v2/specs/appcenter.ms/v0.1/swagger.json",
-    "updated": "2021-06-21T12:16:53.715Z",
-    "result": {
-      "valid": false,
-      "errors": [
-        {
-          "instancePath": "/paths/~1v0.1~1apps~1{owner_name}~1{app_name}~1branches/get/responses/200/schema/items/properties/lastBuild/properties/id/exclusiveMinimum",
-          "schemaPath": "http://json-schema.org/draft-07/schema#/properties/exclusiveMinimum/type",
-          "keyword": "type",
-          "params": {
-            "type": "number"
-          },
-          "message": "must be number"
-        },
-        {
-          "instancePath": "/paths/~1v0.1~1apps~1{owner_name}~1{app_name}~1branches/get/responses/200/schema/items",
-          "schemaPath": "#/properties/items/anyOf/1/type",
-          "keyword": "type",
-          "params": {
-            "type": "array"
-          },
-          "message": "must be array"
-        },
-        {
-          "instancePath": "/paths/~1v0.1~1apps~1{owner_name}~1{app_name}~1branches/get/responses/200/schema/items",
-          "schemaPath": "#/properties/items/anyOf",
-          "keyword": "anyOf",
-          "params": {},
-          "message": "must match a schema in anyOf"
-        },
-        {
-          "instancePath": "/paths/~1v0.1~1apps~1{owner_name}~1{app_name}~1branches/get/responses/200/schema",
-          "schemaPath": "#/additionalProperties",
-          "keyword": "additionalProperties",
-          "params": {
-            "additionalProperty": "items"
-          },
-          "message": "must NOT have additional properties"
-        },
-        {
-          "instancePath": "/paths/~1v0.1~1apps~1{owner_name}~1{app_name}~1branches/get/responses/200/schema",
-          "schemaPath": "#/properties/schema/oneOf",
-          "keyword": "oneOf",
-          "params": {
-            "passingSchemas": null
-          },
-          "message": "must match exactly one schema in oneOf"
-        },
-        {
-          "instancePath": "/paths/~1v0.1~1apps~1{owner_name}~1{app_name}~1branches/get/responses/200",
-          "schemaPath": "#/required",
-          "keyword": "required",
-          "params": {
-            "missingProperty": "$ref"
-          },
-          "message": "must have required property '$ref'"
-        },
-        {
-          "instancePath": "/paths/~1v0.1~1apps~1{owner_name}~1{app_name}~1branches/get/responses/200",
-          "schemaPath": "#/oneOf",
-          "keyword": "oneOf",
-          "params": {
-            "passingSchemas": null
-          },
-          "message": "must match exactly one schema in oneOf"
-        }
-      ]
-    },
-    "knownFailed": true
-  },
   "ato.gov.au": {
     "name": "ato.gov.au",
     "apiVersion": "0.0.6",
@@ -115,167 +40,6 @@
     },
     "knownFailed": true
   },
-  "azure.com:cdn": {
-    "name": "azure.com:cdn",
-    "apiVersion": "2019-12-31",
-    "openApiVersion": "2.0",
-    "yamlUrl": "https://api.apis.guru/v2/specs/azure.com/cdn/2019-12-31/swagger.yaml",
-    "jsonUrl": "https://api.apis.guru/v2/specs/azure.com/cdn/2019-12-31/swagger.json",
-    "updated": null,
-    "result": {
-      "valid": false,
-      "errors": [
-        {
-          "instancePath": "/definitions/DeepCreatedOriginProperties/properties/httpPort/exclusiveMaximum",
-          "schemaPath": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum/type",
-          "keyword": "type",
-          "params": {
-            "type": "number"
-          },
-          "message": "must be number"
-        }
-      ]
-    },
-    "knownFailed": true
-  },
-  "azure.com:cdn-cdnwebapplicationfirewall": {
-    "name": "azure.com:cdn-cdnwebapplicationfirewall",
-    "apiVersion": "2019-06-15-preview",
-    "openApiVersion": "2.0",
-    "yamlUrl": "https://api.apis.guru/v2/specs/azure.com/cdn-cdnwebapplicationfirewall/2019-06-15-preview/swagger.yaml",
-    "jsonUrl": "https://api.apis.guru/v2/specs/azure.com/cdn-cdnwebapplicationfirewall/2019-06-15-preview/swagger.json",
-    "updated": null,
-    "result": {
-      "valid": false,
-      "errors": [
-        {
-          "instancePath": "/definitions/CustomRule/properties/priority/exclusiveMaximum",
-          "schemaPath": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum/type",
-          "keyword": "type",
-          "params": {
-            "type": "number"
-          },
-          "message": "must be number"
-        }
-      ]
-    },
-    "knownFailed": true
-  },
-  "azure.com:cognitiveservices-FormRecognizer": {
-    "name": "azure.com:cognitiveservices-FormRecognizer",
-    "apiVersion": "2.0-preview",
-    "openApiVersion": "2.0",
-    "yamlUrl": "https://api.apis.guru/v2/specs/azure.com/cognitiveservices-FormRecognizer/2.0-preview/swagger.yaml",
-    "jsonUrl": "https://api.apis.guru/v2/specs/azure.com/cognitiveservices-FormRecognizer/2.0-preview/swagger.json",
-    "updated": "2020-03-17T10:27:09.000Z",
-    "result": {
-      "valid": false,
-      "errors": [
-        {
-          "instancePath": "/definitions/ReadResult/properties/angle/exclusiveMinimum",
-          "schemaPath": "http://json-schema.org/draft-07/schema#/properties/exclusiveMinimum/type",
-          "keyword": "type",
-          "params": {
-            "type": "number"
-          },
-          "message": "must be number"
-        }
-      ]
-    },
-    "knownFailed": true
-  },
-  "azure.com:frontdoor": {
-    "name": "azure.com:frontdoor",
-    "apiVersion": "2020-01-01",
-    "openApiVersion": "2.0",
-    "yamlUrl": "https://api.apis.guru/v2/specs/azure.com/frontdoor/2020-01-01/swagger.yaml",
-    "jsonUrl": "https://api.apis.guru/v2/specs/azure.com/frontdoor/2020-01-01/swagger.json",
-    "updated": null,
-    "result": {
-      "valid": false,
-      "errors": [
-        {
-          "instancePath": "/definitions/Backend/properties/httpPort/exclusiveMaximum",
-          "schemaPath": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum/type",
-          "keyword": "type",
-          "params": {
-            "type": "number"
-          },
-          "message": "must be number"
-        }
-      ]
-    },
-    "knownFailed": true
-  },
-  "azure.com:network-applicationGateway": {
-    "name": "azure.com:network-applicationGateway",
-    "apiVersion": "2019-08-01",
-    "openApiVersion": "2.0",
-    "yamlUrl": "https://api.apis.guru/v2/specs/azure.com/network-applicationGateway/2019-08-01/swagger.yaml",
-    "jsonUrl": "https://api.apis.guru/v2/specs/azure.com/network-applicationGateway/2019-08-01/swagger.json",
-    "updated": "2020-07-16T08:09:03.635Z",
-    "result": {
-      "valid": false,
-      "errors": [
-        {
-          "instancePath": "/definitions/ApplicationGatewayAutoscaleConfiguration/properties/maxCapacity/exclusiveMinimum",
-          "schemaPath": "http://json-schema.org/draft-07/schema#/properties/exclusiveMinimum/type",
-          "keyword": "type",
-          "params": {
-            "type": "number"
-          },
-          "message": "must be number"
-        }
-      ]
-    },
-    "knownFailed": true
-  },
-  "azure.com:network-azureFirewall": {
-    "name": "azure.com:network-azureFirewall",
-    "apiVersion": "2019-08-01",
-    "openApiVersion": "2.0",
-    "yamlUrl": "https://api.apis.guru/v2/specs/azure.com/network-azureFirewall/2019-08-01/swagger.yaml",
-    "jsonUrl": "https://api.apis.guru/v2/specs/azure.com/network-azureFirewall/2019-08-01/swagger.json",
-    "updated": null,
-    "result": {
-      "valid": false,
-      "errors": [
-        {
-          "instancePath": "/definitions/AzureFirewallApplicationRuleCollectionPropertiesFormat/properties/priority/exclusiveMaximum",
-          "schemaPath": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum/type",
-          "keyword": "type",
-          "params": {
-            "type": "number"
-          },
-          "message": "must be number"
-        }
-      ]
-    },
-    "knownFailed": true
-  },
-  "azure.com:network-firewallPolicy": {
-    "name": "azure.com:network-firewallPolicy",
-    "apiVersion": "2019-08-01",
-    "openApiVersion": "2.0",
-    "yamlUrl": "https://api.apis.guru/v2/specs/azure.com/network-firewallPolicy/2019-08-01/swagger.yaml",
-    "jsonUrl": "https://api.apis.guru/v2/specs/azure.com/network-firewallPolicy/2019-08-01/swagger.json",
-    "updated": null,
-    "result": {
-      "valid": false,
-      "errors": [
-        {
-          "instancePath": "/definitions/FirewallPolicyRule/properties/priority/exclusiveMaximum",
-          "schemaPath": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum/type",
-          "keyword": "type",
-          "params": {
-            "type": "number"
-          },
-          "message": "must be number"
-        }
-      ]
-    },
-    "knownFailed": true
-  },
   "bluemix.net:containers": {
     "name": "bluemix.net:containers",
     "apiVersion": "3.0.0",
@@ -297,39 +61,47 @@
         },
         {
           "instancePath": "/paths/~1build/post/parameters/6/in",
-          "schemaPath": "#/properties/in/const",
-          "keyword": "const",
+          "schemaPath": "#/properties/in/enum",
+          "keyword": "enum",
           "params": {
-            "allowedValue": "header"
+            "allowedValues": [
+              "header"
+            ]
           },
-          "message": "must be equal to constant"
+          "message": "must be equal to one of the allowed values"
         },
         {
           "instancePath": "/paths/~1build/post/parameters/6/in",
-          "schemaPath": "#/properties/in/const",
-          "keyword": "const",
+          "schemaPath": "#/properties/in/enum",
+          "keyword": "enum",
           "params": {
-            "allowedValue": "formData"
+            "allowedValues": [
+              "formData"
+            ]
           },
-          "message": "must be equal to constant"
+          "message": "must be equal to one of the allowed values"
         },
         {
           "instancePath": "/paths/~1build/post/parameters/6/in",
-          "schemaPath": "#/properties/in/const",
-          "keyword": "const",
+          "schemaPath": "#/properties/in/enum",
+          "keyword": "enum",
           "params": {
-            "allowedValue": "query"
+            "allowedValues": [
+              "query"
+            ]
           },
-          "message": "must be equal to constant"
+          "message": "must be equal to one of the allowed values"
         },
         {
           "instancePath": "/paths/~1build/post/parameters/6/in",
-          "schemaPath": "#/properties/in/const",
-          "keyword": "const",
+          "schemaPath": "#/properties/in/enum",
+          "keyword": "enum",
           "params": {
-            "allowedValue": "path"
+            "allowedValues": [
+              "path"
+            ]
           },
-          "message": "must be equal to constant"
+          "message": "must be equal to one of the allowed values"
         },
         {
           "instancePath": "/paths/~1build/post/parameters/6",
@@ -368,8 +140,7 @@
           "message": "must match exactly one schema in oneOf"
         }
       ]
-    },
-    "knownFailed": true
+    }
   },
   "britbox.co.uk": {
     "name": "britbox.co.uk",
@@ -471,106 +242,6 @@
     },
     "knownFailed": true
   },
-  "lyft.com": {
-    "name": "lyft.com",
-    "apiVersion": "1.0.0",
-    "openApiVersion": "2.0",
-    "yamlUrl": "https://api.apis.guru/v2/specs/lyft.com/1.0.0/swagger.yaml",
-    "jsonUrl": "https://api.apis.guru/v2/specs/lyft.com/1.0.0/swagger.json",
-    "updated": "2018-11-28T10:43:55.000Z",
-    "result": {
-      "valid": false,
-      "errors": [
-        {
-          "instancePath": "/parameters/OptionalLimit",
-          "schemaPath": "#/required",
-          "keyword": "required",
-          "params": {
-            "missingProperty": "schema"
-          },
-          "message": "must have required property 'schema'"
-        },
-        {
-          "instancePath": "/parameters/OptionalLimit/in",
-          "schemaPath": "#/properties/in/const",
-          "keyword": "const",
-          "params": {
-            "allowedValue": "header"
-          },
-          "message": "must be equal to constant"
-        },
-        {
-          "instancePath": "/parameters/OptionalLimit/in",
-          "schemaPath": "#/properties/in/const",
-          "keyword": "const",
-          "params": {
-            "allowedValue": "formData"
-          },
-          "message": "must be equal to constant"
-        },
-        {
-          "instancePath": "/parameters/OptionalLimit/exclusiveMaximum",
-          "schemaPath": "#/definitions/exclusiveMaximum/type",
-          "keyword": "type",
-          "params": {
-            "type": "number"
-          },
-          "message": "must be number"
-        },
-        {
-          "instancePath": "/parameters/OptionalLimit",
-          "schemaPath": "#/required",
-          "keyword": "required",
-          "params": {
-            "missingProperty": "required"
-          },
-          "message": "must have required property 'required'"
-        },
-        {
-          "instancePath": "/parameters/OptionalLimit",
-          "schemaPath": "#/oneOf",
-          "keyword": "oneOf",
-          "params": {
-            "passingSchemas": null
-          },
-          "message": "must match exactly one schema in oneOf"
-        },
-        {
-          "instancePath": "/parameters/OptionalLimit",
-          "schemaPath": "#/oneOf",
-          "keyword": "oneOf",
-          "params": {
-            "passingSchemas": null
-          },
-          "message": "must match exactly one schema in oneOf"
-        }
-      ]
-    },
-    "knownFailed": true
-  },
-  "mastercard.com:open-banking-connect-pis": {
-    "name": "mastercard.com:open-banking-connect-pis",
-    "apiVersion": "1.16.0",
-    "openApiVersion": "2.0",
-    "yamlUrl": "https://api.apis.guru/v2/specs/mastercard.com/open-banking-connect-pis/1.16.0/swagger.yaml",
-    "jsonUrl": "https://api.apis.guru/v2/specs/mastercard.com/open-banking-connect-pis/1.16.0/swagger.json",
-    "updated": "2020-08-24T15:45:12.170Z",
-    "result": {
-      "valid": false,
-      "errors": [
-        {
-          "instancePath": "/definitions/postPaymentsCrossBorderCreditTransfersConsentsParamsBodyPaymentsInstructedAmount/properties/amount/exclusiveMinimum",
-          "schemaPath": "http://json-schema.org/draft-07/schema#/properties/exclusiveMinimum/type",
-          "keyword": "type",
-          "params": {
-            "type": "number"
-          },
-          "message": "must be number"
-        }
-      ]
-    },
-    "knownFailed": true
-  },
   "nasa.gov:apod": {
     "name": "nasa.gov:apod",
     "apiVersion": "1.0.0",
@@ -664,29 +335,6 @@
             "passingSchemas": null
           },
           "message": "must match exactly one schema in oneOf"
-        }
-      ]
-    },
-    "knownFailed": true
-  },
-  "zalando.com": {
-    "name": "zalando.com",
-    "apiVersion": "v1.0",
-    "openApiVersion": "2.0",
-    "yamlUrl": "https://api.apis.guru/v2/specs/zalando.com/v1.0/swagger.yaml",
-    "jsonUrl": "https://api.apis.guru/v2/specs/zalando.com/v1.0/swagger.json",
-    "updated": "2018-09-27T12:24:15.000Z",
-    "result": {
-      "valid": false,
-      "errors": [
-        {
-          "instancePath": "/definitions/Domain/properties/taxRate/exclusiveMaximum",
-          "schemaPath": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum/type",
-          "keyword": "type",
-          "params": {
-            "type": "number"
-          },
-          "message": "must be number"
         }
       ]
     },


### PR DESCRIPTION
This solves issues resulting from the conversion of draft-04 specs to draft-07 specs. 
Most notably:  "exclusiveMinimum" and "exclusiveMaximum" have been changed from a boolean to a number to be consistent with the principle of keyword independence between JSON-schema-draft04 and JSON-schema-draft07