### PR TITLE
fix: add addSpecRef to index.d.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 ### Changed
 
+## [v2.1.2] 27-09-2023
+### Changed 
+ - fix: added addSpecRef() to index.d.ts
+ - Updated dependencies
+   - @biomejs/biome  ^1.1.2  →  ^1.2.2
+
 ## [v2.1.1] 13-09-2023
 ### Changed 
  - chore: added Biome for formatting and linting

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Where `<filename>` refers to a YAML or JSON file containing the specification.
 - [`<instance>.specification`](#specification)
 - [`<instance>.version`](#version)
 - [`<instance>.resolveRefs(options)`](#resolveRefs)
-- [`<instance>.addSpecRef(uri, subSpecification)`](#addSpecRef)
+- [`<instance>.addSpecRef(subSpecification, uri)`](#addSpecRef)
 - [`Validator.supportedVersions`](#supportedVersions)
 
 <a name="newValidator"></a>

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ export class Validator {
 		valid: boolean;
 		errors?: ErrorObject[];
 	}>;
+	addSpecRef(schema:object | string, uri:string):void; 
 	specification: object;
 	version: string;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ export class Validator {
 		valid: boolean;
 		errors?: ErrorObject[];
 	}>;
-	addSpecRef(schema:object | string, uri:string):void; 
+	addSpecRef(schema: object | string, uri: string): void;
 	specification: object;
 	version: string;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "validate-api": "bin/validate-api-cli.js"
       },
       "devDependencies": {
-        "@biomejs/biome": "^1.1.2",
+        "@biomejs/biome": "^1.2.2",
         "c8": "^8.0.1"
       }
     },
@@ -29,9 +29,9 @@
       "dev": true
     },
     "node_modules/@biomejs/biome": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.1.2.tgz",
-      "integrity": "sha512-JEVWchqo0Xhl86IJgOh0xESWnNRUXBUDByCBR8TA4lIPzm/6U6Tv77+MblNkZ8MvwCtP6PlBNGdQcGKKabtuHA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.2.2.tgz",
+      "integrity": "sha512-fXwXi56ZdaKO/N3rTmhWw41UxstoviODk+wia4WWNSlm23r8xJ/NxjaZ88scV2IsmsFHqc8rmwb2dkrStAdIEw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -41,18 +41,18 @@
         "node": ">=14.*"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.1.2",
-        "@biomejs/cli-darwin-x64": "1.1.2",
-        "@biomejs/cli-linux-arm64": "1.1.2",
-        "@biomejs/cli-linux-x64": "1.1.2",
-        "@biomejs/cli-win32-arm64": "1.1.2",
-        "@biomejs/cli-win32-x64": "1.1.2"
+        "@biomejs/cli-darwin-arm64": "1.2.2",
+        "@biomejs/cli-darwin-x64": "1.2.2",
+        "@biomejs/cli-linux-arm64": "1.2.2",
+        "@biomejs/cli-linux-x64": "1.2.2",
+        "@biomejs/cli-win32-arm64": "1.2.2",
+        "@biomejs/cli-win32-x64": "1.2.2"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.1.2.tgz",
-      "integrity": "sha512-YyqWeNZchPxlvxtdo2vMBkzrwllaNS3+DZ6j01mUCVIZE9kAzF/edMV2O38L2AEtnRLU1TI1f71Jai3ThILClg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.2.2.tgz",
+      "integrity": "sha512-Fx1IURKhoqH6wPawtKLT6wcfMSjRRcNK8+VWau0iDOjXvNtjJpSmICbU89B7Vt/gZRwPqkfDMBkFwm6V5vFTSQ==",
       "cpu": [
         "arm64"
       ],
@@ -66,9 +66,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.1.2.tgz",
-      "integrity": "sha512-Sofxcu50AHJyQS6Xx3OF2egQQ7Un5YFVF5/umNFa+kSNrrCu/ucmzrk8FcGS2dOSs4L2LqD6ZDWjvbcikjzLYQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.2.2.tgz",
+      "integrity": "sha512-JNaAFOI/ZisnmzvcFNd73geJxaFaN2L4YsWM6cgBeKyLY/ycl9C/PBTFfEmeB1c7f5XIIal8P2cj47kLJpN5Ig==",
       "cpu": [
         "x64"
       ],
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.1.2.tgz",
-      "integrity": "sha512-wtaQgpoVMZEKf1GlDlFGAJP1j6gnh4L4kJN8PQPOBAdKIUZ/YSjqVp0z28vli5xCQ57xCn1gH4Xoqw2gVYu1tQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.2.2.tgz",
+      "integrity": "sha512-JHXRnfhOLx8UO/Fcyn2c5pFRri0XKqRZm2wf5oH5GSfLVpckDw2X15dYGbu3nmfM/3pcAaTV46pUpjrCnaAieg==",
       "cpu": [
         "arm64"
       ],
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.1.2.tgz",
-      "integrity": "sha512-TYIUjCXbY+kxnJgv8GESplMagB1GdOcMV21JGRATqnhUI4BvG6sjs3gfi+sdjLBQdbHhsISXW3yfUlv07HKqhg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.2.2.tgz",
+      "integrity": "sha512-5Zr+iM7lUKsw81p9PkXRESuH2/AhRZ6RCWkgE+FSLcxMhXy/4RDR+o2YQDsJM6cWKIzOJM05vDHTGrDq7vXE4A==",
       "cpu": [
         "x64"
       ],
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.1.2.tgz",
-      "integrity": "sha512-yApn85KuJ+Ty5zxbqWnaifX4ONtZG+snu12RNKi8fxSVVCXzQ/k2PfsWQbsyvCG05qshSvNKtM54cuf+vhUIsw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.2.2.tgz",
+      "integrity": "sha512-HvUcG2p++RvYP0zfOqh+DgiUUH+JI/uETr0kzWlOJ9F3lsG525pkywg4RSd4OvJd7Wpd3wt3UpN/A4IEJaVmbA==",
       "cpu": [
         "arm64"
       ],
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.1.2.tgz",
-      "integrity": "sha512-qebNvIrFj2TJ+K0JVGo1HkgV2y5jis6aOZDC1SWuk53GnqjSLdR+p1v86ZByOjYr1v+tjc67EXmEepk06VVvpA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.2.2.tgz",
+      "integrity": "sha512-bfaFJwqJ9ApFga2o88OaROSd3pasYRzRGXHJWAE9VUUKdSNSTYxHOqVrNvV54yYPtL6Kt9xkuZa4HNu9it3TaA==",
       "cpu": [
         "x64"
       ],
@@ -926,58 +926,58 @@
       "dev": true
     },
     "@biomejs/biome": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.1.2.tgz",
-      "integrity": "sha512-JEVWchqo0Xhl86IJgOh0xESWnNRUXBUDByCBR8TA4lIPzm/6U6Tv77+MblNkZ8MvwCtP6PlBNGdQcGKKabtuHA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.2.2.tgz",
+      "integrity": "sha512-fXwXi56ZdaKO/N3rTmhWw41UxstoviODk+wia4WWNSlm23r8xJ/NxjaZ88scV2IsmsFHqc8rmwb2dkrStAdIEw==",
       "dev": true,
       "requires": {
-        "@biomejs/cli-darwin-arm64": "1.1.2",
-        "@biomejs/cli-darwin-x64": "1.1.2",
-        "@biomejs/cli-linux-arm64": "1.1.2",
-        "@biomejs/cli-linux-x64": "1.1.2",
-        "@biomejs/cli-win32-arm64": "1.1.2",
-        "@biomejs/cli-win32-x64": "1.1.2"
+        "@biomejs/cli-darwin-arm64": "1.2.2",
+        "@biomejs/cli-darwin-x64": "1.2.2",
+        "@biomejs/cli-linux-arm64": "1.2.2",
+        "@biomejs/cli-linux-x64": "1.2.2",
+        "@biomejs/cli-win32-arm64": "1.2.2",
+        "@biomejs/cli-win32-x64": "1.2.2"
       }
     },
     "@biomejs/cli-darwin-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.1.2.tgz",
-      "integrity": "sha512-YyqWeNZchPxlvxtdo2vMBkzrwllaNS3+DZ6j01mUCVIZE9kAzF/edMV2O38L2AEtnRLU1TI1f71Jai3ThILClg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.2.2.tgz",
+      "integrity": "sha512-Fx1IURKhoqH6wPawtKLT6wcfMSjRRcNK8+VWau0iDOjXvNtjJpSmICbU89B7Vt/gZRwPqkfDMBkFwm6V5vFTSQ==",
       "dev": true,
       "optional": true
     },
     "@biomejs/cli-darwin-x64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.1.2.tgz",
-      "integrity": "sha512-Sofxcu50AHJyQS6Xx3OF2egQQ7Un5YFVF5/umNFa+kSNrrCu/ucmzrk8FcGS2dOSs4L2LqD6ZDWjvbcikjzLYQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.2.2.tgz",
+      "integrity": "sha512-JNaAFOI/ZisnmzvcFNd73geJxaFaN2L4YsWM6cgBeKyLY/ycl9C/PBTFfEmeB1c7f5XIIal8P2cj47kLJpN5Ig==",
       "dev": true,
       "optional": true
     },
     "@biomejs/cli-linux-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.1.2.tgz",
-      "integrity": "sha512-wtaQgpoVMZEKf1GlDlFGAJP1j6gnh4L4kJN8PQPOBAdKIUZ/YSjqVp0z28vli5xCQ57xCn1gH4Xoqw2gVYu1tQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.2.2.tgz",
+      "integrity": "sha512-JHXRnfhOLx8UO/Fcyn2c5pFRri0XKqRZm2wf5oH5GSfLVpckDw2X15dYGbu3nmfM/3pcAaTV46pUpjrCnaAieg==",
       "dev": true,
       "optional": true
     },
     "@biomejs/cli-linux-x64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.1.2.tgz",
-      "integrity": "sha512-TYIUjCXbY+kxnJgv8GESplMagB1GdOcMV21JGRATqnhUI4BvG6sjs3gfi+sdjLBQdbHhsISXW3yfUlv07HKqhg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.2.2.tgz",
+      "integrity": "sha512-5Zr+iM7lUKsw81p9PkXRESuH2/AhRZ6RCWkgE+FSLcxMhXy/4RDR+o2YQDsJM6cWKIzOJM05vDHTGrDq7vXE4A==",
       "dev": true,
       "optional": true
     },
     "@biomejs/cli-win32-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.1.2.tgz",
-      "integrity": "sha512-yApn85KuJ+Ty5zxbqWnaifX4ONtZG+snu12RNKi8fxSVVCXzQ/k2PfsWQbsyvCG05qshSvNKtM54cuf+vhUIsw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.2.2.tgz",
+      "integrity": "sha512-HvUcG2p++RvYP0zfOqh+DgiUUH+JI/uETr0kzWlOJ9F3lsG525pkywg4RSd4OvJd7Wpd3wt3UpN/A4IEJaVmbA==",
       "dev": true,
       "optional": true
     },
     "@biomejs/cli-win32-x64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.1.2.tgz",
-      "integrity": "sha512-qebNvIrFj2TJ+K0JVGo1HkgV2y5jis6aOZDC1SWuk53GnqjSLdR+p1v86ZByOjYr1v+tjc67EXmEepk06VVvpA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.2.2.tgz",
+      "integrity": "sha512-bfaFJwqJ9ApFga2o88OaROSd3pasYRzRGXHJWAE9VUUKdSNSTYxHOqVrNvV54yYPtL6Kt9xkuZa4HNu9it3TaA==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "author": "Hans Klunder",
   "license": "MIT",
   "devDependencies": {
-    "@biomejs/biome": "^1.1.2",
+    "@biomejs/biome": "^1.2.2",
     "c8": "^8.0.1"
   },
   "directories": {


### PR DESCRIPTION
This PR adds addSpecRef() to index.d.ts and fixes a bug in README.md
It also updates dependencies:
- @biomejs/biome  ^1.1.2  →  ^1.2.2

This fixes: #113 