### PR TITLE
Remove lts/-1 from windows build

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -15,6 +15,9 @@ jobs:
       matrix:
         node-version: ["lts/-1", "lts/*", "node"]
         os: [ubuntu-latest, windows-latest]
+        exclude: 
+          - os: windows-latest
+            node-version: "lts/-1"
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
The combination of "windows-latest" and "lts/-1" consistently gives the error:
`Could not find 'D:\a\openapi-schema-validator\openapi-schema-validator\test\*.test.js'` while it does work for `node` and `lts/*` and also for `node`, `lts/*` and `lts/-1` on Linux.

Therefore this PR excludes the combination of "windows-latest" and "lts/-1" from CI.
