### PR TITLE
chore: replace minimist by node:util.parseArgs

### DIFF
--- a/bin/bundle-api-cli.js
+++ b/bin/bundle-api-cli.js
@@ -4,7 +4,7 @@ import { writeFileSync } from "node:fs";
 import { basename } from "node:path";
 import { argv, exit } from "node:process";
 import { dump } from "js-yaml";
-import argvParser from "minimist";
+import { parseArgs } from "node:util";
 import { Validator } from "../index.js";
 
 const cmd = basename(argv[1]);
@@ -47,34 +47,44 @@ The output will be a validated JSON specification.
 	exit(1);
 }
 
+// Define the options for parseArgs
 const argvOptions = {
-	string: ["output", "type", "_"],
-	alias: {
-		output: "o",
-		type: "t",
+	options: {
+		output: {
+			type: "string",
+			short: "o",
+			default: undefined,
+		},
+		type: {
+			type: "string",
+			short: "t",
+			default: "JSON",
+		},
+		help: {
+			type: "boolean",
+			short: "h",
+		},
 	},
-
-	default: {
-		output: false,
-		type: "JSON",
-	},
+	allowPositionals: true,
 };
 
-const args = argvParser(argv.slice(2), argvOptions);
-const type = args.type.toUpperCase();
+// Parse arguments
+const { values, positionals } = parseArgs(argvOptions);
+
+const type = values.type.toUpperCase();
 if (!validTypes.has(type)) {
-	console.log(`Unknown type: ${args.type}`);
+	console.log(`Unknown type: ${values.type}`);
 	usage();
 }
 
-if (args._.length === 0) {
+if (positionals.length === 0) {
 	usage();
 }
 
-const result = await validator.validateBundle(args._);
+const result = await validator.validateBundle(positionals);
 
 if (result.valid) {
-	writeOutput(args.output, formatOutput(type, validator.specification));
+	writeOutput(values.output, formatOutput(type, validator.specification));
 	exit(0);
 }
 

--- a/bin/bundle-api-cli.js
+++ b/bin/bundle-api-cli.js
@@ -3,8 +3,8 @@
 import { writeFileSync } from "node:fs";
 import { basename } from "node:path";
 import { argv, exit } from "node:process";
-import { dump } from "js-yaml";
 import { parseArgs } from "node:util";
+import { dump } from "js-yaml";
 import { Validator } from "../index.js";
 
 const cmd = basename(argv[1]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
 				"ajv": "^8.17.1",
 				"ajv-draft-04": "^1.0.0",
 				"ajv-formats": "^3.0.1",
-				"js-yaml": "^4.1.0",
-				"minimist": "^1.2.8"
+				"js-yaml": "^4.1.0"
 			},
 			"bin": {
 				"bundle-api": "bin/bundle-api-cli.js",
@@ -870,14 +869,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/minipass": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -1689,11 +1680,6 @@
 			"requires": {
 				"brace-expansion": "^2.0.1"
 			}
-		},
-		"minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
 		},
 		"minipass": {
 			"version": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
 		"ajv": "^8.17.1",
 		"ajv-draft-04": "^1.0.0",
 		"ajv-formats": "^3.0.1",
-		"js-yaml": "^4.1.0",
-		"minimist": "^1.2.8"
+		"js-yaml": "^4.1.0"
 	},
 	"scripts": {
 		"test": "c8 node --test test/test-*.js",


### PR DESCRIPTION
This PR replaces minimist by node:util.parseArgs, reducing the number of dependencies.