### PR TITLE
fix(types): refine Validator options disallowing boolean values for `strict`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,12 @@
 import type { ErrorObject, Options } from "ajv";
+
+interface ValidatorOptions extends Omit<Options, "strict"> {
+	strict?: Extract<Options, "log">;
+}
+
 export class Validator {
 	static supportedVersions: Set<string>;
-	constructor(ajvOptions?: Options);
+	constructor(ajvOptions?: ValidatorOptions);
 	resolveRefs(opts?: { specification?: object }): object;
 	validate(schema: object | string): Promise<{
 		valid: boolean;


### PR DESCRIPTION
This PR updates the type definitions to make it explicit that the only valid value for the `strict` option is `"log"`.
Boolean values are silently ignored, so this just clarifies the intended usage 😅.

https://github.com/seriousme/openapi-schema-validator/blob/7e6c9068ade7ea137ef65720bacec89c33de18c5/index.js#L69-L73