### PR TITLE
chore(biome): use `vcs.useIgnoreFile` to avoid duplicating `.gitignore` values

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+*.jsonc text eol=lf 
 *.json text eol=lf 
 *.js text eol=lf 
 *.ts text eol=lf 

--- a/biome.json
+++ b/biome.json
@@ -1,14 +1,11 @@
 {
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
 	"files": {
-		"includes": [
-			"**",
-			"!**/.nyc_output",
-			"!**/coverage",
-			"!**/schemas",
-			"!**/schemas.orig",
-			"!**/dummy.json",
-			"!**/package.json"
-		]
+		"includes": ["**", "!**/schemas", "!**/schemas.orig", "!**/dummy.json"]
 	},
 	"linter": {
 		"enabled": true,

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -5,7 +5,18 @@
 		"useIgnoreFile": true
 	},
 	"files": {
-		"includes": ["**", "!**/schemas", "!**/schemas.orig", "!**/dummy.json"]
+		"includes": [
+			"**",
+			"!**/schemas",
+			"!**/schemas.orig",
+			"!**/dummy.json",
+
+			/**
+			 * `npm version` updates `package.json` in such a way that `biome format` sometimes breaks CI.
+			 * @see https://github.com/seriousme/openapi-schema-validator/pull/195#issuecomment-3193470031
+			 */
+			"!**/package.json"
+		]
 	},
 	"linter": {
 		"enabled": true,


### PR DESCRIPTION
This PR enables the `vcs` configuration options in `biome`, allowing the use of `useIgnoreFile`.
This prevents duplication of `.gitignore` entries in `files.include`.

Reference: https://biomejs.dev/reference/configuration/#vcsuseignorefile