### PR TITLE
feat: improve error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Where `<filename>` refers to a YAML or JSON file containing the specification.
 ### CLI for API bundling
 
 To make it easier to combine multiple YAML or JSON files into a single specification file there is the `bundle-api` command.
-(see the [validateBundle](#validateBundle) section below) 
+(see the [validateBundle](#validateBundle) section below)
 
 ```bash
 npm install @seriousme/openapi-schema-validator -g
@@ -127,7 +127,7 @@ is not a bug but a result of the complexity of the openApi JSON schemas.
 
 ### `<instance>.validate(specification)`
 
-This function tries to validata a specification against the OpenApi schemas.
+This function tries to validate a specification against the OpenApi schemas.
 `specification` can be one of:
 
 - a JSON object
@@ -152,14 +152,14 @@ object:
 
 If the validator managed to extract data from the specification parameter then
 the extracted specification is available in this property as javascript object.
-E.g. if you supplied a filename of a YAML file and the file was sucessfully read
+E.g. if you supplied a filename of a YAML file and the file was successfully read
 and its YAML decoded then the contents is here. Even if validation failed.
 
 <a name="version"></a>
 
 ### `<instance>.version`
 
-If validation is succesfull this will return the openApi version found e.g.
+If validation is successful this will return the openApi version found e.g.
 ("2.0","3.0","3.1). The openApi specification only specifies major/minor
 versions as separate schemas. So "3.0.3" results in "3.0".
 
@@ -170,7 +170,7 @@ versions as separate schemas. So "3.0.3" results in "3.0".
 This function tries to resolve all internal references. External references are
 _not_ automatically resolved so you need to inline them yourself if required e.g
 by using `<instance>.addSpecRef()`. By default it will use the last
-specification passed to `<instance>.validate()` but you can explicity pass a
+specification passed to `<instance>.validate()` but you can explicitly pass a
 specification by passing `{specification:<object>}` as options. The result is an
 `object` where all references have been resolved. Resolution of references is
 `shallow` This should normally not be a problem for this use case.
@@ -184,7 +184,7 @@ specification by passing `{specification:<object>}` as options. The result is an
 - a JSON object
 - a JSON object encoded as string
 - a YAML string
-- a filename 
+- a filename
 
 `uri` must be a string (e.g. `http://www.example.com/subspec`), but
   is not required if the subSpecification holds a `$id` attribute at top level.

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -81,7 +81,7 @@ test("undefined specification should fail", async (t) => {
 	t.assert.equal(res.valid, false, "undefined specification is invalid");
 	t.assert.equal(
 		res.errors,
-		"Cannot find JSON, YAML or filename in data",
+		'Invalid input type. Expected "string" or "object", but got "undefined"',
 		"correct error message",
 	);
 });
@@ -180,8 +180,8 @@ test("invalid yaml specification as string gives an error", async (t) => {
 	t.assert.equal(res.valid, false, "validation fails as expected");
 	t.assert.equal(
 		res.errors,
-		"Cannot find JSON, YAML or filename in data",
-		"error message matches expection",
+		"Failed to parse input as YAML/JSON",
+		"error message matches expectation",
 	);
 });
 
@@ -243,35 +243,35 @@ test("invalid filename returns an error", async (t) => {
 	t.assert.equal(res.valid, false, "validation fails as expected");
 	t.assert.equal(
 		res.errors,
-		"Cannot find JSON, YAML or filename in data",
-		"error message matches expection",
+		'Could not read file "nonExistingFilename"',
+		"error message matches expectation",
 	);
 });
 
 test("addSpecRef: non string URI throws an error", async (t) => {
 	const validator = new Validator();
-	t.assert.rejects(
+	await t.assert.rejects(
 		validator.addSpecRef(subSpecYamlFileName, null),
 		new Error("uri parameter or $id attribute must be a string"),
-		"error message matches expection",
+		"error message matches expectation",
 	);
 });
 
 test("addSpecRef: Invalid filename returns an error", async (t) => {
 	const validator = new Validator();
-	t.assert.rejects(
+	await t.assert.rejects(
 		validator.addSpecRef("nonExistingFilename", "extraUri"),
-		new Error("Cannot find JSON, YAML or filename in data"),
-		"error message matches expection",
+		new Error('Could not read file "nonExistingFilename"'),
+		"error message matches expectation",
 	);
 });
 
-test("addSpecRef: no uri and no $id attribute returns an error", (t) => {
+test("addSpecRef: no uri and no $id attribute returns an error", async (t) => {
 	const validator = new Validator();
-	t.assert.rejects(
+	await t.assert.rejects(
 		validator.addSpecRef(subSpecYamlFileName),
 		new Error("uri parameter or $id attribute must be a string"),
-		"error message matches expection",
+		"error message matches expectation",
 	);
 });
 
@@ -347,7 +347,7 @@ test("validateBundle: no spec returns an error", async (t) => {
 	t.assert.equal(
 		res.errors,
 		"Parameter data must be an array",
-		"error message matches expection",
+		"error message matches expectation",
 	);
 });
 
@@ -357,16 +357,16 @@ test("validateBundle: unreadable spec returns an error", async (t) => {
 	yaml : : :
 	`;
 	const validator = new Validator();
-	t.assert.rejects(
-		validator.validateBundle([yamlSpec]),
-		new Error("Cannot find JSON, YAML or filename in data"),
+	await t.assert.rejects(
+		() => validator.validateBundle([yamlSpec]),
+		new Error("Failed to parse input as YAML/JSON"),
 		"error message matches expectation",
 	);
 });
 
 test("validateBundle: double spec returns an error", async (t) => {
 	const validator = new Validator();
-	t.assert.rejects(
+	await t.assert.rejects(
 		validator.validateBundle([yamlFileName, yamlFileName]),
 		new Error("Only one openApi specification can be validated at a time"),
 		"error message matches expectation",

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -358,7 +358,7 @@ test("validateBundle: unreadable spec returns an error", async (t) => {
 	`;
 	const validator = new Validator();
 	await t.assert.rejects(
-		() => validator.validateBundle([yamlSpec]),
+		validator.validateBundle([yamlSpec]),
 		new Error("Failed to parse input as YAML/JSON"),
 		"error message matches expectation",
 	);


### PR DESCRIPTION
* Follow-up on https://github.com/seriousme/openapi-schema-validator/pull/200#discussion_r2283216135

---

* `getSpecFromData` → `loadSpecFromData`

  * Renamed for clarity.
  * Now returns a `loaded: boolean` flag indicating whether the spec was successfully parsed.
    * When `loaded` is `false`, the output includes an `errorMessage` field that can be used either to throw an error or as the error string when returning a `ValidationResult` (`Validator#validateBundle`).
    * When `loaded` is `true`, the result includes the `spec` and an optional `fileName`, which can be used to continue the validation process.
  * Improved error messages to better describe the actual issue.

* Test improvements

  * Added `await` to some `t.assert.rejects` calls.

    * This prevents unhandled rejection warnings that occasionally appeared after test runs completed.

* README
  * Fixed some typos.
