### PR TITLE
chore(realworld): fix format

### DIFF
--- a/test/realworld/realworld.js
+++ b/test/realworld/realworld.js
@@ -165,22 +165,24 @@ async function fetchApiList(percentage, onlyFailed = false) {
 }
 
 async function fetchYaml(url, retries = 3) {
-    for (let attempt = 1; attempt <= retries; attempt++) {
-        try {
-            const controller = new AbortController();
-            const timeout = setTimeout(() => controller.abort(), 15000); // 15s timeout
-            const response = await fetch(url, { signal: controller.signal });
-            clearTimeout(timeout);
+	for (let attempt = 1; attempt <= retries; attempt++) {
+		try {
+			const controller = new AbortController();
+			const timeout = setTimeout(() => controller.abort(), 15000); // 15s timeout
+			const response = await fetch(url, { signal: controller.signal });
+			clearTimeout(timeout);
 
-            if (!response.ok) {
-                throw new Error(`Unable to download ${url}`);
-            }
-            return await response.text();
-        } catch (error) {
-            if (attempt === retries || error.name !== 'AbortError') throw error;
-            console.warn(`Retrying fetch for ${url} (attempt ${attempt}) due to timeout...`);
-        }
-    }
+			if (!response.ok) {
+				throw new Error(`Unable to download ${url}`);
+			}
+			return await response.text();
+		} catch (error) {
+			if (attempt === retries || error.name !== "AbortError") throw error;
+			console.warn(
+				`Retrying fetch for ${url} (attempt ${attempt}) due to timeout...`,
+			);
+		}
+	}
 }
 
 function writeReport(ci, totalSize, results, failed) {


### PR DESCRIPTION
I pulled the latest changes from the repo to test an additional improvement, 
and noticed that the lint script is now failing due to incorrect formatting in the `test/realworld/realworld.js` file.

To validate the changes, I executed `npm run realWorldTest` three times, and no errors were reported.