### PR TITLE
feat: updated OpenApi schema 3.1 to version 2025-08-31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 ### Changed
- - updated dependencies
+
+## [v2.6.0] 14-09-2025
+### Changed 
+ - feat: updated OpenApi schema 3.1 to version 2025-08-31
+ - chore(dev): updated dependencies
    - @biomejs/biome   ^2.2.0  →   ^2.2.4
    - @types/node     ^24.3.0  →  ^24.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 ### Changed
+ - updated dependencies
+   - @biomejs/biome   ^2.2.0  →   ^2.2.4
+   - @types/node     ^24.3.0  →  ^24.3.3
 
 ## [v2.5.0] 19-08-2025
 ### Changed 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
 				"validate-api": "bin/validate-api-cli.js"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.2.0",
+				"@biomejs/biome": "^2.2.4",
 				"@types/js-yaml": "^4.0.9",
-				"@types/node": "^24.3.0",
+				"@types/node": "^24.3.3",
 				"c8": "^10.1.3",
 				"expect-type": "^1.2.2",
 				"typescript": "^5.9.2"
@@ -282,9 +282,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.3.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
-			"integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+			"version": "24.3.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.3.tgz",
+			"integrity": "sha512-GKBNHjoNw3Kra1Qg5UXttsY5kiWMEfoHq2TmXb+b1rcm6N7B3wTrFYIf/oSZ1xNQ+hVVijgLkiDZh7jRRsh+Gw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
 	"author": "Hans Klunder",
 	"license": "MIT",
 	"devDependencies": {
-		"@biomejs/biome": "^2.2.0",
+		"@biomejs/biome": "^2.2.4",
 		"@types/js-yaml": "^4.0.9",
-		"@types/node": "^24.3.0",
+		"@types/node": "^24.3.3",
 		"c8": "^10.1.3",
 		"expect-type": "^1.2.2",
 		"typescript": "^5.9.2"

--- a/schemas/v3.1/schema.json
+++ b/schemas/v3.1/schema.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://spec.openapis.org/oas/3.1/schema/2025-02-13",
+	"$id": "https://spec.openapis.org/oas/3.1/schema/2025-08-31",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"description": "The description of OpenAPI v3.1.x Documents without Schema Object validation",
 	"type": "object",
@@ -907,7 +907,7 @@
 				"description": {
 					"type": "string"
 				},
-				"body": {
+				"server": {
 					"$ref": "#/$defs/server"
 				}
 			},
@@ -1370,6 +1370,12 @@
 						"$ref": "#/$defs/example-or-reference"
 					}
 				}
+			},
+			"not": {
+				"required": [
+					"example",
+					"examples"
+				]
 			}
 		},
 		"map-of-strings": {

--- a/test/snapshots-check-versions.json
+++ b/test/snapshots-check-versions.json
@@ -1,5 +1,5 @@
 {
 	"schema v3.0 is unchanged": "66e985dbc28010b540f45327e10b775e5415045e741191a4b84fefa50ef1796f",
-	"schema v3.1 is unchanged": "4fcb3c4a3b7642f93c86bc793ab8ad4aedd2e7b3164082d9fdceda3a3d996069",
+	"schema v3.1 is unchanged": "73ca9c85e16d50f573504db84ff8db3b087c8be2dea49b03f070f36ba8409664",
 	"schema v2.0 is unchanged": "220e4d47e8dbd8f72a612898429b970bfd652e663569f7202002ceb9767e033a"
 }


### PR DESCRIPTION

 - feat: updated OpenApi schema 3.1 to version 2025-08-31
 - chore(dev): updated dependencies
   - @biomejs/biome   ^2.2.0  →   ^2.2.4
   - @types/node     ^24.3.0  →  ^24.3.3