### PR TITLE
Update nodejs-ci.yml to use CodeCov

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -26,19 +26,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci --ignore-scripts --no-audit --no-progress --prefer-offline
       - run: npm run test:ci
-      - name: Coveralls Parallel
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ matrix.test_number }}
-          parallel: true
-
-  finish:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.github_token }}
-          parallel-finished: true
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5


### PR DESCRIPTION
Given all the problems with coveralls.io this PR migrates to codecov.io