### PR TITLE
feat: replace js-yaml by yaml

### DIFF
--- a/bin/bundle-api-cli.js
+++ b/bin/bundle-api-cli.js
@@ -4,7 +4,7 @@ import { writeFileSync } from "node:fs";
 import { basename } from "node:path";
 import { argv, exit } from "node:process";
 import { parseArgs } from "node:util";
-import { dump } from "js-yaml";
+import { stringify } from "yaml";
 import { Validator } from "../index.js";
 
 const cmd = basename(argv[1]);
@@ -13,7 +13,7 @@ const validTypes = new Set(["JSON", "YAML"]);
 
 function formatOutput(type, data) {
 	if (type === "YAML") {
-		return dump(data);
+		return stringify(data);
 	}
 	return JSON.stringify(data, null, 2);
 }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import { fileURLToPath, URL } from "node:url";
 import Ajv2020 from "ajv/dist/2020.js";
 import Ajv04 from "ajv-draft-04";
 import addFormatsModule from "ajv-formats";
-import { JSON_SCHEMA, load } from "js-yaml";
+import { parse } from "yaml";
 import { checkRefs, replaceRefs } from "./resolve.js";
 
 /** @typedef {import("ajv/dist/core.js").default} AjvCore */
@@ -122,9 +122,7 @@ async function loadSpecFromData(data) {
 		return {
 			loaded: true,
 			fileName,
-			spec: /** @type {SpecFromData} */ (
-				load(sourceData, { schema: JSON_SCHEMA })
-			),
+			spec: /** @type {SpecFromData} */ (parse(sourceData)),
 		};
 	} catch (_) {
 		return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"ajv": "^8.18.0",
 				"ajv-draft-04": "^1.0.0",
 				"ajv-formats": "^3.0.1",
-				"js-yaml": "^4.1.1"
+				"yaml": "^2.8.3"
 			},
 			"bin": {
 				"bundle-api": "bin/bundle-api-cli.js",
@@ -20,7 +20,6 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.4.3",
-				"@types/js-yaml": "^4.0.9",
 				"@types/node": "^25.3.0",
 				"expect-type": "^1.3.0",
 				"typescript": "^6.0.2"
@@ -189,13 +188,6 @@
 				"node": ">=14.21.3"
 			}
 		},
-		"node_modules/@types/js-yaml": {
-			"version": "4.0.9",
-			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-			"integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/node": {
 			"version": "25.6.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -253,12 +245,6 @@
 				}
 			}
 		},
-		"node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"license": "Python-2.0"
-		},
 		"node_modules/expect-type": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -290,18 +276,6 @@
 				}
 			],
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "1.0.0",
@@ -338,6 +312,21 @@
 			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/yaml": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"ajv": "^8.18.0",
 		"ajv-draft-04": "^1.0.0",
 		"ajv-formats": "^3.0.1",
-		"js-yaml": "^4.1.1"
+		"yaml": "^2.8.3"
 	},
 	"scripts": {
 		"test:typescript": "tsc --project tsconfig.test.json",
@@ -38,7 +38,6 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.3",
-		"@types/js-yaml": "^4.0.9",
 		"@types/node": "^25.3.0",
 		"expect-type": "^1.3.0",
 		"typescript": "^6.0.2"

--- a/test/realworld/realworld.js
+++ b/test/realworld/realworld.js
@@ -10,10 +10,9 @@ const validator = new Validator();
 
 import { writeFileSync } from "node:fs";
 import { argv, exit } from "node:process";
-import { JSON_SCHEMA, load } from "js-yaml";
+import { parse } from "yaml";
 import { createReport } from "./createReport.js";
 
-const yamlOpts = { schema: JSON_SCHEMA };
 const failedFile = localFile("./failed.json");
 const reportFile = localFile("./failed.md");
 const newFailedFile = localFile("./failed.updated.json");
@@ -117,7 +116,7 @@ function getInstanceValue(yamlSpec, path) {
 	if (path === "") {
 		return [false, "content too large to display here"];
 	}
-	const obj = load(yamlSpec, yamlOpts);
+	const obj = parse(yamlSpec);
 	const paths = path.split("/").slice(1);
 	const result = paths.reduce((o, n) => o[unescapeJsonPointer(n)], obj);
 	return [true, result];

--- a/test/test-bundle-cli.js
+++ b/test/test-bundle-cli.js
@@ -55,7 +55,7 @@ test("cli bundles subspecs as YAML to file", (t) => {
 	execSync(
 		`node ${cli} -t yaml -o ${tmpBundle} ${main} ${subspec} ${subspec2}`,
 	);
-	const result = parse(readFileSync(tmpBundle, 'utf8'));
+	const result = parse(readFileSync(tmpBundle, "utf8"));
 	unlinkSync(tmpBundle);
 	t.assert.deepEqual(result, bundle);
 });

--- a/test/test-bundle-cli.js
+++ b/test/test-bundle-cli.js
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import { readFileSync, unlinkSync } from "node:fs";
 import { test } from "node:test";
 import { fileURLToPath, URL } from "node:url";
-import { load } from "js-yaml";
+import { parse } from "yaml";
 
 function localFile(fileName) {
 	return fileURLToPath(new URL(fileName, import.meta.url));
@@ -55,7 +55,7 @@ test("cli bundles subspecs as YAML to file", (t) => {
 	execSync(
 		`node ${cli} -t yaml -o ${tmpBundle} ${main} ${subspec} ${subspec2}`,
 	);
-	const result = load(readFileSync(tmpBundle));
+	const result = parse(readFileSync(tmpBundle, 'utf8'));
 	unlinkSync(tmpBundle);
 	t.assert.deepEqual(result, bundle);
 });


### PR DESCRIPTION
This PR replaces js-yaml by yaml  as advised by https://e18e.dev/docs/replacements/js-yaml.html