### PR TITLE
chore:update dependencies ajv 8.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 ### Changed
+ - chore: updated dependencies
+   - @types/node     ^25.6.0  →  ^25.9.1
+   - ajv             ^8.18.0  →  ^8.20.0
+   - typescript       ^6.0.2  →   ^6.0.3
+   - yaml             ^2.8.3  →   ^2.9.0
 
 ## [v2.9.0] 15-04-2026
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,20 @@
 			"version": "2.9.0",
 			"license": "MIT",
 			"dependencies": {
-				"ajv": "^8.18.0",
+				"ajv": "^8.20.0",
 				"ajv-draft-04": "^1.0.0",
 				"ajv-formats": "^3.0.1",
-				"yaml": "^2.8.3"
+				"yaml": "^2.9.0"
 			},
 			"bin": {
 				"bundle-api": "bin/bundle-api-cli.js",
 				"validate-api": "bin/validate-api-cli.js"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.4.12",
-				"@types/node": "^25.6.0",
+				"@biomejs/biome": "^2.4.16",
+				"@types/node": "^25.9.1",
 				"expect-type": "^1.3.0",
-				"typescript": "^6.0.2"
+				"typescript": "^6.0.3"
 			}
 		},
 		"node_modules/@biomejs/biome": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
 		"bundle-api": "./bin/bundle-api-cli.js"
 	},
 	"dependencies": {
-		"ajv": "^8.18.0",
+		"ajv": "^8.20.0",
 		"ajv-draft-04": "^1.0.0",
 		"ajv-formats": "^3.0.1",
-		"yaml": "^2.8.3"
+		"yaml": "^2.9.0"
 	},
 	"scripts": {
 		"test:typescript": "tsc --project tsconfig.test.json",
@@ -37,10 +37,10 @@
 	"author": "Hans Klunder",
 	"license": "MIT",
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.12",
-		"@types/node": "^25.6.0",
+		"@biomejs/biome": "^2.4.16",
+		"@types/node": "^25.9.1",
 		"expect-type": "^1.3.0",
-		"typescript": "^6.0.2"
+		"typescript": "^6.0.3"
 	},
 	"directories": {
 		"test": "test"


### PR DESCRIPTION
### Changed
 - chore: updated dependencies
   - @types/node     ^25.6.0  →  ^25.9.1
   - ajv             ^8.18.0  →  ^8.20.0
   - typescript       ^6.0.2  →   ^6.0.3
   - yaml             ^2.8.3  →   ^2.9.0