### PR TITLE
chore: update dependencies biome 2.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## [Unreleased]
 ### Changed
  - chore: updated dependencies
-   - @types/node     ^25.6.0  →  ^25.9.1
+   - @types/node     ^25.6.0  →  ^26.1.2
    - ajv             ^8.18.0  →  ^8.20.0
    - typescript       ^6.0.2  →   ^6.0.3
    - yaml             ^2.8.3  →   ^2.9.0
+   - @biomejs/biome  ^2.4.16  →   ^2.5.7
+   - expect-type      ^1.3.0  →   ^1.4.0
 
 ## [v2.9.0] 15-04-2026
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,16 +19,16 @@
 				"validate-api": "bin/validate-api-cli.js"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.4.16",
-				"@types/node": "^26.0.0",
-				"expect-type": "^1.3.0",
+				"@biomejs/biome": "^2.5.7",
+				"@types/node": "^26.1.2",
+				"expect-type": "^1.4.0",
 				"typescript": "^7.0.2"
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.6.tgz",
-			"integrity": "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.7.tgz",
+			"integrity": "sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -42,20 +42,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.6",
-				"@biomejs/cli-darwin-x64": "2.5.6",
-				"@biomejs/cli-linux-arm64": "2.5.6",
-				"@biomejs/cli-linux-arm64-musl": "2.5.6",
-				"@biomejs/cli-linux-x64": "2.5.6",
-				"@biomejs/cli-linux-x64-musl": "2.5.6",
-				"@biomejs/cli-win32-arm64": "2.5.6",
-				"@biomejs/cli-win32-x64": "2.5.6"
+				"@biomejs/cli-darwin-arm64": "2.5.7",
+				"@biomejs/cli-darwin-x64": "2.5.7",
+				"@biomejs/cli-linux-arm64": "2.5.7",
+				"@biomejs/cli-linux-arm64-musl": "2.5.7",
+				"@biomejs/cli-linux-x64": "2.5.7",
+				"@biomejs/cli-linux-x64-musl": "2.5.7",
+				"@biomejs/cli-win32-arm64": "2.5.7",
+				"@biomejs/cli-win32-x64": "2.5.7"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.6.tgz",
-			"integrity": "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.7.tgz",
+			"integrity": "sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw==",
 			"cpu": [
 				"arm64"
 			],
@@ -70,9 +70,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.6.tgz",
-			"integrity": "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.7.tgz",
+			"integrity": "sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg==",
 			"cpu": [
 				"x64"
 			],
@@ -87,9 +87,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.6.tgz",
-			"integrity": "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.7.tgz",
+			"integrity": "sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg==",
 			"cpu": [
 				"arm64"
 			],
@@ -107,9 +107,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.6.tgz",
-			"integrity": "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.7.tgz",
+			"integrity": "sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -127,9 +127,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.6.tgz",
-			"integrity": "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.7.tgz",
+			"integrity": "sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q==",
 			"cpu": [
 				"x64"
 			],
@@ -147,9 +147,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.6.tgz",
-			"integrity": "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.7.tgz",
+			"integrity": "sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g==",
 			"cpu": [
 				"x64"
 			],
@@ -167,9 +167,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.6.tgz",
-			"integrity": "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.7.tgz",
+			"integrity": "sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg==",
 			"cpu": [
 				"arm64"
 			],
@@ -184,9 +184,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.6.tgz",
-			"integrity": "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==",
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.7.tgz",
+			"integrity": "sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ==",
 			"cpu": [
 				"x64"
 			],

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
 	"author": "Hans Klunder",
 	"license": "MIT",
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.16",
-		"@types/node": "^26.0.0",
-		"expect-type": "^1.3.0",
+		"@biomejs/biome": "^2.5.7",
+		"@types/node": "^26.1.2",
+		"expect-type": "^1.4.0",
 		"typescript": "^7.0.2"
 	},
 	"directories": {


### PR DESCRIPTION
updated dependencies:

-  @biomejs/biome  ^2.4.16  →   ^2.5.7
-  @types/node     ^26.0.0  →  ^26.1.2
-  expect-type      ^1.3.0  →   ^1.4.0